### PR TITLE
avoid unnecessary clones

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -364,7 +364,7 @@ pub struct Format {
 
 /// Action that describes the metadata of the table.
 /// This is a top-level action in Delta log entries.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaData {
     /// Unique identifier for this table


### PR DESCRIPTION
For methods/functions that does clone internally, it's better to pass in arguments by value to pass along the ownership so the caller gets decide whether a clone is needed or not.